### PR TITLE
zustandのインポート時のwarning対応

### DIFF
--- a/src/stores/notifications.ts
+++ b/src/stores/notifications.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid'
-import create from 'zustand'
+import { create } from 'zustand'
 
 interface Notification {
   id: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -2677,6 +2677,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"


### PR DESCRIPTION
### issue
```
[DEPRECATED] Default export is deprecated. Instead use `import { create } from 'zustand'`.
```