### PR TITLE
next/image関連のwarning対応

### DIFF
--- a/src/components/Elements/Card/Card.tsx
+++ b/src/components/Elements/Card/Card.tsx
@@ -13,14 +13,16 @@ interface CardProps {
 export const Card: React.FC<CardProps> = ({ title, cover, date, tags }) => (
   <div className='border-b border-placeholder px-3 py-2 sm:min-h-[160px] sm:px-5 sm:py-4'>
     <div className='flex flex-col gap-4 sm:flex-row sm:gap-8'>
-      <div className='flex h-32 justify-center'>
-        <Image
-          className='object-contain'
-          src={cover}
-          width={128}
-          height={128}
-          alt='記事で扱うメイン技術のイメージ'
-        />
+      <div className='flex justify-center'>
+        <div className='relative h-32 w-32'>
+          <Image
+            className='object-contain'
+            fill
+            sizes='100%'
+            src={cover}
+            alt='記事で扱うメイン技術のイメージ'
+          />
+        </div>
       </div>
       <div className='flex flex-col justify-between gap-2 tracking-wide sm:w-[calc(100%_-_144px)] sm:gap-4'>
         <div className='flex justify-end gap-4 text-sm font-normal text-placeholder sm:gap-8 sm:text-lg'>

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -38,7 +38,7 @@ const Navigation: React.FC = () => {
 
 const Logo: React.FC = () => (
   <Link href='/articles'>
-    <Image src='/logo.png' width={240} height={40} alt='logo' />
+    <Image src='/logo.png' width={240} height={40} alt='logo' className='h-auto w-auto' />
   </Link>
 )
 


### PR DESCRIPTION
### issue
```
either width or height modified, but not the other. If you use CSS to change the size of your image, also include the styles 'width: "auto"' or 'height: "auto"' to maintain the aspect ratio.
```

### 対応
下記参考に。
https://github.com/vercel/next.js/blob/canary/examples/image-component/pages/fill.tsx