### PR TITLE
tailwindのline-clampがデフォルトで組み込まれたので削除

### DIFF
--- a/INIT.md
+++ b/INIT.md
@@ -141,7 +141,7 @@ $ docker-compose run --rm app yarn add -D eslint-plugin-sort-keys-custom-order e
 ```
 $ docker-compose run --rm app yarn add -D tailwindcss postcss autoprefixer
 $ docker-compose run --rm app yarn tailwindcss init -p
-$ docker-compose run --rm app yarn add -D eslint-plugin-tailwindcss @tailwindcss/typography @tailwindcss/forms @tailwindcss/line-clamp
+$ docker-compose run --rm app yarn add -D eslint-plugin-tailwindcss @tailwindcss/typography @tailwindcss/forms
 ```
 
 ```diff
@@ -153,7 +153,6 @@ module.exports = {
 +  plugins: [
 +      require("@tailwindcss/typography"),
 +      require("@tailwindcss/forms"),
-+      require("@tailwindcss/line-clamp")
 +  ],
   theme: {
     extend: {}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "@notionhq/client": "2.2.4",
     "@tailwindcss/forms": "^0.5.3",
-    "@tailwindcss/line-clamp": "^0.4.4",
     "@tailwindcss/typography": "^0.5.9",
     "@types/node": "18.15.13",
     "@types/react": "18.0.21",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
-  plugins: [
-    require('@tailwindcss/typography'),
-    require('@tailwindcss/forms'),
-    require('@tailwindcss/line-clamp')
-  ],
+  plugins: [require('@tailwindcss/typography'), require('@tailwindcss/forms')],
   theme: {
     extend: {
       colors: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -250,11 +250,6 @@
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
-"@tailwindcss/line-clamp@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz#767cf8e5d528a5d90c9740ca66eb079f5e87d423"
-  integrity sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==
-
 "@tailwindcss/typography@^0.5.9":
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.9.tgz#027e4b0674929daaf7c921c900beee80dbad93e8"


### PR DESCRIPTION
### issue
tailwindcss v3.3.0からline-clampはデフォルトになったので削除する
https://tailwindcss.com/docs/line-clamp